### PR TITLE
[Interpolated] Added support for the square-bracket index notation

### DIFF
--- a/pretf/pretf/render.py
+++ b/pretf/pretf/render.py
@@ -83,6 +83,9 @@ class Interpolated:
     def __getattr__(self, attr: str) -> "Interpolated":
         return type(self)(self.__value + "." + attr)
 
+    def __getitem__(self, index: int) -> "Interpolated":
+        return type(self)(f"{self.__value}[{index}]")
+
     def __repr__(self) -> str:
         return f"Interpolated({repr(self.__value)})"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,3 +14,13 @@ def test_provider_alias_default():
 def test_variable():
     one = block("variable", "one", {})
     assert str(one) == "${var.one}"
+
+
+def test_index_interpolation():
+    instance = block("resource", "aws_instance", "www", {}).ipv6_addresses[0]
+    assert str(instance) == "${aws_instance.www.ipv6_addresses[0]}"
+
+
+def test_nested_index_interpolation():
+    interpolated = block("resource", "one", "two", {}).list[0].another_list[1]
+    assert str(interpolated) == "${one.two.list[0].another_list[1]}"


### PR DESCRIPTION
First thank you for this awesome project, I was using a resource that has a list of IPv6 addresses and I needed to reference the first one using the square-bracket notation, for example `${aws_instance.name.ipv6_addresses[0]}`

Currently if we try to get an interpolated string with an index, we get a `TypeError`:

```python
>>> block('resource', 'aws_instance', 'name', {}).ipv6_addresses[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'Interpolated' object does not support indexing
```

So I added support for using indexes by adding `__getitem__` on the `Interpolated` class, and now the same code returns an expressions usable by Terraform:

```python
>>> block('resource', 'aws_instance', 'name', {}).ipv6_addresses[0]
Interpolated('aws_instance.name.ipv6_addresses[0]')
```

If my code doesn't conform to your guidelines, please feel free to implement this functionality with your own code.

By the way can you please add how to contribute to the README file? like how to setup for development and how to run the tests?

Again thank you very much for this project.