### PR TITLE
[Block] Make __str__ and __getattr__ return consistent values

### DIFF
--- a/pretf/pretf/render.py
+++ b/pretf/pretf/render.py
@@ -34,7 +34,7 @@ class Block(Iterable):
             result = self._body
         yield (self._block_type, result)
 
-    def __getattr__(self, name: str) -> Union["Interpolated", str]:
+    def _get_expression(self, name: Optional[str] = None) -> Union["Interpolated", str]:
         if self._block_type == "resource":
             parts = list(self._labels)
         elif self._block_type == "variable":
@@ -53,8 +53,14 @@ class Block(Iterable):
             parts = ["local"]
         else:
             parts = [self._block_type] + list(self._labels)
-        parts.append(name)
+
+        if name:
+            parts.append(name)
+
         return Interpolated(".".join(parts))
+
+    def __getattr__(self, name: str) -> Union["Interpolated", str]:
+        return self._get_expression(name)
 
     __getitem__ = __getattr__
 
@@ -66,11 +72,7 @@ class Block(Iterable):
         return f"block({', '.join(repr(part) for part in parts)})"
 
     def __str__(self) -> str:
-        if self._block_type == "variable":
-            parts = ["var"] + self._labels
-            return str(Interpolated(".".join(parts)))
-        else:
-            return ".".join([self._block_type] + self._labels)
+        return str(self._get_expression())
 
 
 class Interpolated:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,3 +14,7 @@ def test_provider_alias_default():
 def test_variable():
     one = block("variable", "one", {})
     assert str(one) == "${var.one}"
+
+def test_resource():
+    resource = block("resource", "one", "two", {})
+    assert str(resource) == "${one.two}"

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -68,7 +68,9 @@ def aws_iam_user_group_membership(var):
     yield block("variable", "users", {})
 
     # Resources.
-    group_label = str(var.group).split(".")[-1]
+    # Get the group name from the interpolated string
+    # Another way to get it is var.group._labels[-1]
+    group_label = str(var.group).strip('${}').split(".")[-1]
     for user_label, user in sorted(var.users.items()):
         label = f"{user_label}_in_{group_label}"
         yield block(

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pretf.api import block
+from pretf.api import block, labels
 from pretf.collections import collect
 from pretf.exceptions import VariableNotPopulatedError
 from pretf.render import Block
@@ -68,9 +68,7 @@ def aws_iam_user_group_membership(var):
     yield block("variable", "users", {})
 
     # Resources.
-    # Get the group name from the interpolated string
-    # Another way to get it is var.group._labels[-1]
-    group_label = str(var.group).strip('${}').split(".")[-1]
+    group_label = labels.get(var.group)
     for user_label, user in sorted(var.users.items()):
         label = f"{user_label}_in_{group_label}"
         yield block(


### PR DESCRIPTION
Currently getting the string value of a `resource` `block` returns an invalid Terraform expression:

```python
>>> resource = block("resource", "one", "two", {})
>>> str(resource)
'resource.one.two'
```

Whereas getting the string value of a `variable` works fine, because it's taken into account in the `__str__` method:

```python
>>> var = block("variable", "one", {})
>>> str(var)
'${var.one}'
```

This pull request changes the `__getattr__` and `__str__` methods to use the same method to get the interpolated string usable by Terraform:

```python
>>> resource = block("resource", "one", "two", {})
>>> str(resource)
'${one.two}'
```

This is useful for many cases, especially for defining an `output` value as the entire resource object, before this change this code:

```python
instance = yield block('resource', 'aws_instance', 'web', {})

yield block('output', 'web', {
    'value': instance
})
```

Would generate this JSON code which is not valid:

```json
{
  "output": {
    "web": {
      "value": "resource.aws_instance.web"
    }
  }
}
```

After this change, we will get a valid Terraform expression:

```json
{
  "output": {
    "web": {
      "value": "${aws_instance.web}"
    }
  }
}
```