### PR TITLE
Add block modules

### DIFF
--- a/examples/aws/iam.tf.py
+++ b/examples/aws/iam.tf.py
@@ -1,25 +1,26 @@
-from pretf.api import block, labels
+from pretf.api import labels
+from pretf.blocks import output, resource
 
 
 def pretf_blocks(var):
 
-    group = yield block("resource", "aws_iam_group", "pretf", {
-        "name": "pretf-aws",
-    })
+    group = yield resource.aws_iam_group.pretf(
+        name="pretf-aws",
+    )
 
     for name in var.user_names:
 
         name_label = labels.clean(name)
 
-        user = yield block("resource", "aws_iam_user", name_label, {
-            "name": name,
-        })
+        user = yield resource.aws_iam_user[name_label](
+            name=name,
+        )
 
-        yield block("resource", "aws_iam_user_group_membership", name_label, {
-            "user": user.name,
-            "groups": [group.name],
-        })
+        yield resource.aws_iam_user_group_membership[name_label](
+            user=user.name,
+            groups=[group.name],
+        )
 
-        yield block("output", f"user_{name_label}", {
-            "value": user.name,
-        })
+        yield output[f"user_{name_label}"](
+            value=user.name,
+        )

--- a/examples/aws/security-groups.tf.py
+++ b/examples/aws/security-groups.tf.py
@@ -1,24 +1,18 @@
 from ipaddress import IPv4Network
 
-from pretf.api import block
+from pretf.blocks import output, resource
 
 
 def pretf_blocks(var):
 
     private_label = "private"
-    private = yield block(
-        "resource",
-        "aws_security_group",
-        private_label,
-        {"name": "pretf-example-aws-private"},
+    private = yield resource.aws_security_group[private_label](
+        name="pretf-example-aws-private",
     )
 
     public_label = "public"
-    public = yield block(
-        "resource",
-        "aws_security_group",
-        public_label,
-        {"name": "pretf-example-aws-public"},
+    public = yield resource.aws_security_group[public_label](
+        name="pretf-example-aws-public",
     )
 
     for cidr in sorted(set(var.security_group_allowed_cidrs)):
@@ -34,19 +28,14 @@ def pretf_blocks(var):
 
         for port in (80, 443):
             rule_label = f"{group_label}_{port}_from_{cidr_label}"
-            yield block(
-                "resource",
-                "aws_security_group_rule",
-                rule_label,
-                {
-                    "security_group_id": group.id,
-                    "type": "ingress",
-                    "protocol": "tcp",
-                    "from_port": port,
-                    "to_port": port,
-                    "cidr_blocks": [cidr],
-                },
+            yield resource.aws_security_group_rule[rule_label](
+                security_group_id=group.id,
+                type="ingress",
+                protocol="tcp",
+                from_port=port,
+                to_port=port,
+                cidr_blocks=[cidr],
             )
 
-    yield block("output", "private_sg_id", {"value": private.id})
-    yield block("output", "public_sg_id", {"value": public.id})
+    yield output.private_sg_id(value=private.id)
+    yield output.public_sg_id(value=public.id)

--- a/examples/flatten/stacks/stack.tf.py
+++ b/examples/flatten/stacks/stack.tf.py
@@ -1,13 +1,13 @@
-from pretf.api import block
 from pretf.aws import provider_aws, terraform_backend_s3
+from pretf.blocks import variable
 
 
 def pretf_blocks(var):
 
     # Create variables needed by this file.
 
-    yield block("variable", "aws_credentials", {
-        "default": {
+    yield variable.aws_credentials(
+        default={
             "nonprod": {
                 "profile": "pretf-nonprod",
             },
@@ -15,16 +15,16 @@ def pretf_blocks(var):
                 "profile": "pretf-prod",
             },
         },
-    })
-    yield block("variable", "aws_region", {
-        "default": "eu-west-1",
-    })
-    yield block("variable", "environment", {
-        "type": "string",
-    })
-    yield block("variable", "stack", {
-        "type": "string",
-    })
+    )
+    yield variable.aws_region(
+        default="eu-west-1",
+    )
+    yield variable.environment(
+        type="string",
+    )
+    yield variable.stack(
+        type="string",
+    )
 
     # Create a backend configuration using the environment details.
     # Stacks in the same account share backend resources.

--- a/examples/simple-test/v2/additional.tf.py
+++ b/examples/simple-test/v2/additional.tf.py
@@ -7,14 +7,12 @@ that it works.
 
 """
 
-from pretf.api import block
+from pretf.blocks import output, resource
 
 
 def pretf_blocks(var):
-    additional = yield block(
-        "resource",
-        "random_id",
-        "additional",
-        {"byte_length": 2, "prefix": var.additional_prefix},
+    additional = yield resource.random_id.additional(
+        byte_length=2,
+        prefix=var.additional_prefix,
     )
-    yield block("output", "additional", {"value": additional.hex})
+    yield output.additional(value=additional.hex)

--- a/examples/testing/test_example.py
+++ b/examples/testing/test_example.py
@@ -1,5 +1,5 @@
 from pretf import test, workflow
-from pretf.api import block
+from pretf.blocks import output, variable
 
 
 class TestExample(test.SimpleTest):
@@ -14,8 +14,8 @@ class TestExample(test.SimpleTest):
         workflow.delete_files("*.json")
 
         with self.create("one.tf.json"):
-            one = yield block("variable", "one", {"default": True})
-            yield block("output", "one", {"value": one})
+            one = yield variable.one(default=True)
+            yield output.one(value=one)
 
         self.tf.init()
 
@@ -25,12 +25,12 @@ class TestExample(test.SimpleTest):
     def test_change(self):
 
         with self.create("one.tf.json"):
-            one = yield block("variable", "one", {"default": False})
-            yield block("output", "one", {"value": one})
+            one = yield variable.one(default=False)
+            yield output.one(value=one)
 
         with self.create("two.tf.json"):
-            two = yield block("variable", "two", {"default": {"x": [1, 2, 3], "y": 4}})
-            yield block("output", "two", {"value": two})
+            two = yield variable.two(default={"x": [1, 2, 3], "y": 4})
+            yield output.two(value=two)
 
         outputs = self.tf.apply()
         assert outputs == {"one": False, "two": {"x": [1, 2, 3], "y": 4}}

--- a/examples/vars/a.tf.py
+++ b/examples/vars/a.tf.py
@@ -1,9 +1,7 @@
-from pretf.api import block
+from pretf.blocks import output, variable
 
 
 def pretf_blocks(var):
-    yield block("variable", "one", {"default": 1})
-
-    yield block("output", "one", {"value": var.one})
-
-    yield block("variable", "two", {"default": 2})
+    yield variable.one(default=1)
+    yield output.one(value=var.one)
+    yield variable.two(default=2)

--- a/examples/vars/b.tf.py
+++ b/examples/vars/b.tf.py
@@ -1,15 +1,10 @@
-from pretf.api import block
+from pretf.blocks import output, variable
 
 
 def pretf_blocks(var):
-    yield block("output", "two_attr", {"value": var.two})
-
-    yield block("output", "two_dict", {"value": var["two"]})
-
-    yield block("variable", "three", {"default": 3})
-
-    yield block("output", "three", {"value": var.three})
-
-    yield block("variable", "four", {})
-
-    yield block("output", "four", {"value": var.four})
+    yield output.two_attr(value=var.two)
+    yield output.two_dict(value=var["two"])
+    yield variable.three(default=3)
+    yield output.three(value=var.three)
+    yield variable.four
+    yield output.four(value=var.four)

--- a/examples/vars/d.tf.py
+++ b/examples/vars/d.tf.py
@@ -1,9 +1,7 @@
-from pretf.api import block
+from pretf.blocks import output
 
 
 def pretf_blocks(var):
-    yield block("output", "five", {"value": var.five})
-
-    yield block("output", "six", {"value": var.six})
-
-    yield block("output", "seven", {"value": var.seven})
+    yield output.five(value=var.five)
+    yield output.six(value=var.six)
+    yield output.seven(value=var.seven)

--- a/examples/workspaces/stacks/stack.tf.py
+++ b/examples/workspaces/stacks/stack.tf.py
@@ -1,13 +1,13 @@
-from pretf.api import block
 from pretf.aws import provider_aws, terraform_backend_s3
+from pretf.blocks import variable
 
 
 def pretf_blocks(terraform, var):
 
     # Create variables needed by this file.
 
-    yield block("variable", "aws_credentials", {
-        "default": {
+    yield variable.aws_credentials(
+        default={
             "nonprod": {
                 "profile": "pretf-nonprod",
             },
@@ -15,16 +15,16 @@ def pretf_blocks(terraform, var):
                 "profile": "pretf-prod",
             },
         },
-    })
-    yield block("variable", "aws_region", {
-        "default": "eu-west-1",
-    })
-    yield block("variable", "environment", {
-        "type": "string",
-    })
-    yield block("variable", "stack", {
-        "type": "string",
-    })
+    )
+    yield variable.aws_region(
+        default="eu-west-1",
+    )
+    yield variable.environment(
+        type="string",
+    )
+    yield variable.stack(
+        type="string",
+    )
 
     # Create a backend configuration in the prod account,
     # because all workspaces must use the same backend.

--- a/examples/workspaces/test_workspaces.py
+++ b/examples/workspaces/test_workspaces.py
@@ -10,7 +10,7 @@ class TestWorkspaces(test.SimpleTest):
         "iam",
         "vpc",
         "vpc-peering",
-    ],)
+    ])
     def test_init(self, stack):
         with self.pretf(f"stacks/{stack}") as tf:
             tf.init()

--- a/pretf.aws/pretf/aws.py
+++ b/pretf.aws/pretf/aws.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Any, Optional
 
 from pretf.api import block, log
-from pretf.render import Block
+from pretf.blocks import Block
 
 try:
     from boto_source_profile_mfa import get_session as Session  # type: ignore

--- a/pretf/pretf/api.py
+++ b/pretf/pretf/api.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from . import labels, log
-from .render import Block
+from .blocks import Block
 
 
 def block(block_type: str, *args: Any) -> Block:

--- a/pretf/pretf/blocks.py
+++ b/pretf/pretf/blocks.py
@@ -1,0 +1,157 @@
+from collections.abc import Iterable
+from types import ModuleType
+from typing import Any, Dict, Generator, List, Optional, Union
+
+
+class BlockModule(ModuleType):
+    def __init__(
+        self, block_type: str, labels: Optional[List[str]] = None, needs: int = 0
+    ):
+        if labels is None:
+            labels = []
+
+        self.block_type = block_type
+        self.labels = labels
+        self.needs = needs
+
+        # Also be a module.
+        name = ".".join([__name__, block_type] + labels)
+        self.__path__ = name
+        super().__init__(name)
+
+    def __call__(self, *bodies: Dict[str, Any], **kwargs: Dict[str, Any]) -> "Block":
+        return Block(self.block_type, self.labels, {})(*bodies, **kwargs)
+
+    def __getattr__(self, name: str) -> Union["BlockModule", "Block"]:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        if self.needs == 0:
+            return getattr(Block(self.block_type, self.labels, {}), name)
+        elif self.needs == 1:
+            return Block(self.block_type, self.labels + [name], {})
+        else:
+            return self.__class__(self.block_type, self.labels + [name], self.needs - 1)
+
+    __getitem__ = __getattr__
+
+
+class Block(Iterable):
+    def __init__(self, block_type: str, labels: List[str], body: Dict[str, Any]):
+        self._block_type = block_type
+        self._labels = labels
+        self._body = body
+
+    def __call__(self, *bodies: Dict[str, Any], **kwargs: Dict[str, Any]) -> "Block":
+        """
+        Returns a new block with the specified body.
+
+        """
+
+        body: Dict[str, Any] = {}
+        for each in bodies:
+            body.update(each)
+        body.update(kwargs)
+        return self.__class__(self._block_type, self._labels, body)
+
+    def __iter__(self) -> Generator[tuple, None, None]:
+        if self._labels:
+            result: dict = {}
+            here = result
+            for label in self._labels[:-1]:
+                here[label] = {}
+                here = here[label]
+            here[self._labels[-1]] = self._body
+        else:
+            result = self._body
+        yield (self._block_type, result)
+
+    def _get_expression(self, name: Optional[str] = None) -> Union["Interpolated", str]:
+        if self._block_type == "data":
+            if len(self._labels) < 2:
+                raise ValueError("data blocks require 2 labels")
+            parts = [self._block_type] + list(self._labels)
+        elif self._block_type == "locals":
+            if len(self._labels) < 1 and not name:
+                raise ValueError("locals blocks require 1 label")
+            parts = ["local"] + list(self._labels)
+        elif self._block_type == "module":
+            if len(self._labels) < 1:
+                raise ValueError("module blocks require 1 label")
+            parts = [self._block_type] + list(self._labels)
+        elif self._block_type == "output":
+            if len(self._labels) < 1:
+                raise ValueError("output blocks require 1 label")
+            parts = [self._block_type] + list(self._labels)
+        elif self._block_type == "provider":
+            if len(self._labels) < 1:
+                raise ValueError("provider blocks require 1 label")
+            parts = list(self._labels)
+            if name == "alias" or not name:
+                if self._body:
+                    alias = self._body.get("alias") or "default"
+                    if alias != "default":
+                        parts.append(alias)
+                return ".".join(parts)
+        elif self._block_type == "resource":
+            if len(self._labels) < 2:
+                raise ValueError("resource blocks require 2 labels")
+            parts = list(self._labels)
+        elif self._block_type == "variable":
+            if len(self._labels) < 1:
+                raise ValueError("variable blocks require 1 label")
+            parts = ["var"] + self._labels
+        else:
+            parts = [self._block_type] + list(self._labels)
+
+        if name:
+            parts.append(name)
+
+        return Interpolated(".".join(parts))
+
+    def __getattr__(self, name: str) -> Union["Interpolated", str]:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return self._get_expression(name)
+
+    __getitem__ = __getattr__
+
+    def __repr__(self) -> str:
+        parts: List[Any] = [self._block_type]
+        parts.extend(self._labels)
+        if self._body is not None:
+            parts.append(self._body)
+        return f"block({', '.join(repr(part) for part in parts)})"
+
+    def __str__(self) -> str:
+        return str(self._get_expression())
+
+
+class Interpolated:
+    def __init__(self, value: str):
+        self.__value = value
+
+    def __eq__(self, other: Any) -> bool:
+        return str(self) == other
+
+    def __getattr__(self, attr: str) -> "Interpolated":
+        return type(self)(self.__value + "." + attr)
+
+    def __getitem__(self, index: int) -> "Interpolated":
+        return type(self)(f"{self.__value}[{index}]")
+
+    def __repr__(self) -> str:
+        return f"Interpolated({repr(self.__value)})"
+
+    def __str__(self) -> str:
+        return "${" + self.__value + "}"
+
+
+data = BlockModule("data", needs=2)
+locals = BlockModule("locals", needs=0)
+module = BlockModule("module", needs=1)
+output = BlockModule("output", needs=1)
+provider = BlockModule("provider", needs=1)
+resource = BlockModule("resource", needs=2)
+variable = BlockModule("variable", needs=1)
+
+__all__ = ["data", "locals", "module", "output", "provider", "resource", "variable"]

--- a/pretf/pretf/labels.py
+++ b/pretf/pretf/labels.py
@@ -1,6 +1,6 @@
 import re
 
-from .render import Block
+from .blocks import Block
 
 
 def clean(label: str) -> str:

--- a/pretf/setup.py
+++ b/pretf/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email="ray.butcher@claranet.uk",
     license="MIT License",
     packages=["pretf"],
-    entry_points={"console_scripts": ("pretf=pretf.cli:main",)},
+    entry_points={"console_scripts": ("pretf=pretf.cli:main")},
     install_requires=["colorama", "pyhcl"],
     extras_require={"aws": ["pretf.aws=={}".format(version)]},
     zip_safe=False,

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,69 @@
+from pretf.blocks import data, locals, module, output, provider, resource, variable
+from pretf.render import unwrap_yielded
+
+
+def test_data():
+    assert str(data) == "<module 'pretf.blocks.data'>"
+    assert str(data.null_data_source) == "<module 'pretf.blocks.data.null_data_source'>"
+    assert str(data.null_data_source.test) == "${data.null_data_source.test}"
+
+    # Use index access for dynamic names.
+    assert str(data.null_data_source["test"]) == "${data.null_data_source.test}"
+
+
+def test_locals():
+    assert str(locals) == "<module 'pretf.blocks.locals'>"
+    assert str(locals.test) == "${local.test}"
+
+    # Confirm that the locals block works to generate configuration.
+    assert list(unwrap_yielded(locals(a=1, b=2, c=3))) == [
+        {"locals": {"a": 1, "b": 2, "c": 3}}
+    ]
+
+
+def test_module():
+    assert str(module) == "<module 'pretf.blocks.module'>"
+    assert str(module.test) == "${module.test}"
+
+    # Pass in a dictionary for the body.
+    one = module.one({"a": 1, "b": 2, "c": 3})
+    assert str(one) == "${module.one}"
+
+    # Pass in multiple dictionaries for the body.
+    two = module.two({"a": 1, "b": 2}, {"c": 3})
+    assert str(two) == "${module.two}"
+
+    # Pass in keyword arguments for the body.
+    three = module.three(a=1, b=2, c=3)
+    assert str(three) == "${module.three}"
+
+    # Pass in a dictionary and keyword arguments for the body.
+    four = module.four({"a": 1}, b=2, c=3)
+    assert str(four) == "${module.four}"
+
+    # Pass in multiple dictionaries and keyword arguments for the body.
+    five = module.five({"a": 1}, {"b": 2}, c=3)
+    assert str(five) == "${module.five}"
+
+
+def test_output():
+    assert str(output) == "<module 'pretf.blocks.output'>"
+    assert str(output.test) == "${output.test}"
+
+
+def test_provider():
+    assert str(provider) == "<module 'pretf.blocks.provider'>"
+    assert str(provider.aws) == "aws"
+
+
+def test_resource():
+    assert str(resource) == "<module 'pretf.blocks.resource'>"
+    assert (
+        str(resource.null_resource) == "<module 'pretf.blocks.resource.null_resource'>"
+    )
+    assert str(resource.null_resource.test) == "${null_resource.test}"
+
+
+def test_variable():
+    assert str(variable) == "<module 'pretf.blocks.variable'>"
+    assert str(variable.test) == "${var.test}"

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,9 +1,9 @@
 import pytest
 
 from pretf.api import block, labels
+from pretf.blocks import Block
 from pretf.collections import collect
 from pretf.exceptions import VariableNotPopulatedError
-from pretf.render import Block
 
 
 @collect


### PR DESCRIPTION
This adds a second way to create Terraform configuration blocks that is arguably easier to read and write.

This implements #33 but it still needs documentation. Thanks again to @mdawar for the proposal and example.
