### PR TITLE
Remove pytest requirement from commands

### DIFF
--- a/pretf/pretf/api.py
+++ b/pretf/pretf/api.py
@@ -26,7 +26,7 @@ def get_outputs(cwd: Union[Path, str], verbose: Optional[bool] = None) -> dict:
 
     """
 
-    from pretf.test import PretfProxy
+    from pretf.command import PretfCommand
 
     if isinstance(cwd, Path):
         # Use path as-is.
@@ -80,7 +80,7 @@ def get_outputs(cwd: Union[Path, str], verbose: Optional[bool] = None) -> dict:
                     f"get_outputs({cwd!r}) in {caller_file}: {path} does not exist"
                 )
 
-    outputs = PretfProxy(cwd=path, verbose=False).output()
+    outputs = PretfCommand(cwd=path, verbose=False).output()
 
     values = {}
     for name, data in outputs.items():

--- a/pretf/pretf/command.py
+++ b/pretf/pretf/command.py
@@ -1,0 +1,164 @@
+import os
+import sys
+from json import loads as json_loads
+from pathlib import Path
+from subprocess import CompletedProcess
+from types import TracebackType
+from typing import Any, Optional, Type, Union
+
+from pretf import util, workflow
+
+
+class SensitiveValue:
+    def __init__(self, value: Any):
+        self.value = value
+
+
+class TerraformCommand:
+    def __init__(self, cwd: Union[Path, str] = "", verbose: Optional[bool] = False):
+        if not isinstance(cwd, Path):
+            cwd = Path(cwd)
+        self.cwd = cwd
+        self.env = os.environ.copy()
+        self.env["TF_IN_AUTOMATION"] = "1"
+        self.env["PRETF_VERBOSE"] = "1" if verbose else "0"
+        self.verbose = verbose
+
+    # Calling the object just returns another object with the specified path.
+
+    def __call__(self, cwd: Union[Path, str] = "") -> "TerraformCommand":
+        return self.__class__(cwd or self.cwd)
+
+    # Context manager.
+    # It doesn't do anything but can make the test code easier to follow.
+
+    def __enter__(self) -> "TerraformCommand":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        return None
+
+    # Terraform command.
+
+    def execute(self, *args: str) -> CompletedProcess:
+        return workflow.execute_terraform(
+            args=args,
+            cwd=self.cwd,
+            env=self.env,
+            capture=True,
+            verbose=self.verbose,
+        )
+
+    # Terraform shortcuts.
+
+    def apply(self, *args: str) -> dict:
+        """
+        Runs terraform apply, parses the output for output values,
+        and returns them as a dictionary.
+
+        """
+
+        apply_args = ["apply", "-json", "-auto-approve=true"]
+        for arg in args:
+            if arg not in apply_args:
+                apply_args.append(arg)
+
+        proc = self.execute(*apply_args)
+
+        outputs = None
+        for line in proc.stdout.splitlines():
+            log = json_loads(line)
+            if log["type"] == "outputs":
+                outputs = log["outputs"]
+
+        if outputs is None:
+            if proc.stderr:
+                print(proc.stderr, file=sys.stderr)
+            raise ValueError(f"Could not parse outputs from: {proc.stdout}")
+
+        values = {}
+
+        for name in outputs:
+            value = outputs[name]["value"]
+            if outputs[name]["sensitive"]:
+                value = SensitiveValue(value)
+            values[name] = value
+
+        return values
+
+    def destroy(self, *args: str) -> str:
+        """
+        Runs terraform destroy and returns the stdout.
+
+        """
+
+        destroy_args = ["destroy", "-input=false", "-auto-approve=true", "-no-color"]
+        for arg in args:
+            if arg not in destroy_args:
+                destroy_args.append(arg)
+        return self.execute(*destroy_args).stdout
+
+    def get(self, *args: str) -> str:
+        """
+        Runs terraform get and returns the stdout.
+
+        """
+
+        get_args = ["get", "-no-color"]
+        for arg in args:
+            if arg not in get_args:
+                get_args.append(arg)
+        return self.execute(*get_args).stdout
+
+    def init(self, *args: str) -> str:
+        """
+        Runs terraform init and returns the stdout.
+
+        """
+
+        init_args = ["init", "-input=false", "-no-color"]
+        for arg in args:
+            if arg not in init_args:
+                init_args.append(arg)
+        return self.execute(*init_args).stdout
+
+    def output(self, *args: str) -> dict:
+        """
+        Runs terraform output and returns the JSON.
+
+        """
+
+        output_args = ["output", "-json"]
+        for arg in args:
+            if arg not in output_args:
+                output_args.append(arg)
+        return json_loads(self.execute(*output_args).stdout)
+
+    def plan(self, *args: str) -> str:
+        """
+        Runs terraform plan and returns the stdout.
+
+        """
+
+        plan_args = ["plan", "-input=false", "-no-color"]
+        for arg in args:
+            if arg not in plan_args:
+                plan_args.append(arg)
+        return self.execute(*plan_args).stdout
+
+
+class PretfCommand(TerraformCommand):
+    def execute(self, *args: str) -> CompletedProcess:
+        return util.execute(
+            file="pretf",
+            args=["pretf"] + list(args),
+            cwd=self.cwd,
+            env=self.env,
+            capture=True,
+            verbose=self.verbose,
+        )

--- a/pretf/pretf/workflow.py
+++ b/pretf/pretf/workflow.py
@@ -510,10 +510,10 @@ def link_module(
         module_config_path.write_text(module_json)
 
         # Run "terraform get" to download the module using Terraform.
-        from .test import TerraformProxy
+        from .command import TerraformCommand
 
         terraform_get_args = ["-update"] if update else []
-        TerraformProxy(cwd=cache_dir).get(*terraform_get_args)
+        TerraformCommand(cwd=cache_dir).get(*terraform_get_args)
 
         # Get the path to the module.
         modules_manifest_path = cache_dir / ".terraform" / "modules" / "modules.json"

--- a/pretf/setup.py
+++ b/pretf/setup.py
@@ -21,7 +21,7 @@ setup(
     license="MIT License",
     packages=["pretf"],
     entry_points={"console_scripts": ("pretf=pretf.cli:main")},
-    install_requires=["colorama", "Jinja2", "pytest", "python-hcl2>=3.0.0"],
+    install_requires=["colorama", "Jinja2", "python-hcl2>=3.0.0"],
     extras_require={"aws": ["pretf.aws=={}".format(version)]},
     zip_safe=False,
 )


### PR DESCRIPTION
The link_module and get_outputs functions were using the Proxy class which was in a module that required pytest. This splits things up so that pytest is no longer needed unless you actually want to use pytest-related things.